### PR TITLE
Added a better solution to init porcelain.

### DIFF
--- a/lib/evercam_media.ex
+++ b/lib/evercam_media.ex
@@ -20,6 +20,7 @@ defmodule EvercamMedia do
       worker(ConCache, [[ttl_check: :timer.hours(2), ttl: :timer.hours(24)], [name: :current_camera_status]], id: :current_camera_status),
       worker(ConCache, [[ttl_check: :timer.hours(2), ttl: :timer.hours(6)], [name: :camera_response_times]], id: :camera_response_times),
       worker(EvercamMedia.Scheduler, []),
+      worker(EvercamMedia.Janitor, []),
       supervisor(EvercamMedia.Repo, []),
       supervisor(EvercamMediaWeb.Endpoint, []),
       supervisor(EvercamMedia.SnapshotRepo, []),

--- a/lib/evercam_media/janitor.ex
+++ b/lib/evercam_media/janitor.ex
@@ -1,0 +1,23 @@
+defmodule EvercamMedia.Janitor do
+  use GenServer
+  require Logger
+  @vsn DateTime.to_unix(DateTime.utc_now())
+
+  def start_link() do
+    GenServer.start_link(__MODULE__, :ok, [])
+  end
+
+  def init(_args) do
+    {:ok, 1}
+  end
+
+  def code_change(_old_vsn, state, _extra) do
+    Logger.info "Re-init Porcelain"
+    ensure_porcelain_is_init()
+    {:ok, state}
+  end
+
+  defp ensure_porcelain_is_init do
+    Porcelain.Init.init()
+  end
+end

--- a/lib/evercam_media/janitor.ex
+++ b/lib/evercam_media/janitor.ex
@@ -1,4 +1,10 @@
 defmodule EvercamMedia.Janitor do
+  @moduledoc """
+    This is a Janitor for evercam_media, the purpose of this Module is to do things,
+    which were stopped due to hot upgrade. We encountered Porcelain app to be the one
+    to stop on hot upgrade. We are using code_change/3 callback module to handle this issue.
+  """
+
   use GenServer
   require Logger
   @vsn DateTime.to_unix(DateTime.utc_now())

--- a/lib/evercam_media/snapshot_extractor/extractor_supervisor.ex
+++ b/lib/evercam_media/snapshot_extractor/extractor_supervisor.ex
@@ -3,7 +3,6 @@ defmodule EvercamMedia.SnapshotExtractor.ExtractorSupervisor do
   use Supervisor
   require Logger
   alias EvercamMedia.SnapshotExtractor.Extractor
-  @vsn DateTime.to_unix(DateTime.utc_now())
 
   @root_dir Application.get_env(:evercam_media, :storage_dir)
 
@@ -12,8 +11,6 @@ defmodule EvercamMedia.SnapshotExtractor.ExtractorSupervisor do
   end
 
   def init(:ok) do
-    Logger.info "Re-init Porcelain."
-    Porcelain.Init.init()
     Task.start_link(&initiate_workers/0)
     children = [worker(Extractor, [], restart: :permanent)]
     supervise(children, strategy: :simple_one_for_one, max_restarts: 1_000_000)


### PR DESCRIPTION
FYI:

Porcelain is an application which doesn't handle its state in BEAM.  for almost a week the problem seemed to be Porcelain application was not being started after the hot upgrade, but the issue was worse. It was restarted but its ENVs got lost on hot upgrade. After looking through all its code, it seems like the error generated by Porcelain was misleading.

https://github.com/alco/porcelain/blob/master/lib/porcelain.ex#L419

```elixir
  defp driver() do
    case Application.fetch_env(:porcelain, :driver_internal) do
      {:ok, mod} -> mod
      _ ->
        raise Porcelain.UsageError, message: "Looks like the :porcelain app is not running. " <>
          "Make sure you've added :porcelain to the list of applications in your mix.exs."
    end
  end
```

The application was there in app list and also getting started but `Application.fetch_env(:porcelain, :driver_internal)`, the internal driver set by Porcelain but was losing its value on hot-upgrade.

Solution: There is a part of genServer https://hexdocs.pm/elixir/GenServer.html#c:code_change/3 which basically handle hotupgrade module changes.

When there is a change in Module attributes (`@value`) otp release consider it to be a change and add that module in appup file. to do load, update or add.

we added an attribute with the name of `@vsn` which is basically a version number, and It gets changed on each mix compile, and that module comes in appup file to perform an action, and we are using GenServer's `code_change/3` callback to reinit Porcelain through this.

`Porcelain.Init.init()` is only setting the ENVs for Porcelain again and nothing else.

At first I added it to Extraction Supervisor, but in that, It was doing 2 things

  - On each hot deploy, Init Porcelain
  - And Restart Extractor Supervisor, which was not needed, (Not harmful at all) but not a good approach.

So we added a sperate GenServer for this purpose. and started it as a worker. Now on each hot deploy, on change of  `@vsn` OTP release consider to be a changed state and add it to appup file and Porcelain will get init.

```
  def code_change(_old_vsn, state, _extra) do
    Logger.info "Re-init Porcelain"
    ensure_porcelain_is_init()
```