### PR TITLE
Fixed the size of the snapmail email image for desktop and make it full for mobile devices.

### DIFF
--- a/lib/evercam_media_web/templates/email/snapmail.html.eex
+++ b/lib/evercam_media_web/templates/email/snapmail.html.eex
@@ -9,6 +9,8 @@
 <style type="text/css">
   #image-div img {
     width: 100% !important;
+    max-width: 640px !important;
+    height: auto !important;
   }
   @media only screen and (max-width: 600px) {
     a[class="btn"] {
@@ -19,6 +21,9 @@
     }
     table.social div[class="column"] {
       width: auto !important;
+    }
+    #image-div img {
+      max-width: 100% !important;
     }
   }
   @media only screen and (max-width: 480px){

--- a/lib/evercam_media_web/templates/email/snapmail.html.eex
+++ b/lib/evercam_media_web/templates/email/snapmail.html.eex
@@ -7,11 +7,6 @@
 </head>
 <body bgcolor="#FFFFFF" style="font-family: Arial, Helvetica, sans-serif; -webkit-font-smoothing: antialiased; -webkit-text-size-adjust: none; width: 100% !important; height: 100%; margin: 0; padding: 0;">
 <style type="text/css">
-  #image-div img {
-    width: 100% !important;
-    max-width: 640px !important;
-    height: auto !important;
-  }
   @media only screen and (max-width: 600px) {
     a[class="btn"] {
       display: block !important; margin-bottom: 10px !important; background-image: none !important; margin-right: 0 !important;
@@ -21,9 +16,6 @@
     }
     table.social div[class="column"] {
       width: auto !important;
-    }
-    #image-div img {
-      max-width: 100% !important;
     }
   }
   @media only screen and (max-width: 480px){
@@ -59,7 +51,7 @@
 
       <div class="content" style="font-family: Arial, Helvetica, sans-serif; display: block; margin: 0 auto; padding: 15px;">
         <table style="font-family: Arial, Helvetica, sans-serif; width: 100%; margin: 0; padding: 0;"><tr style="font-family: Arial, Helvetica, sans-serif; margin: 0; padding: 0;">
-          <td id="image-div" style="font-family: Arial, Helvetica, sans-serif; font-weight: normal; font-size: 14px; margin: 0; padding: 0;">
+          <td style="font-family: Arial, Helvetica, sans-serif; font-weight: normal; font-size: 14px; margin: 0; padding: 0;">
 
             <p class="lead" style="line-height: 1.6; margin: 0 0 10px; padding: 0;">Hello, </p>
 

--- a/lib/evercam_media_web/views/email_view.ex
+++ b/lib/evercam_media_web/views/email_view.ex
@@ -40,7 +40,7 @@ defmodule EvercamMediaWeb.EmailView do
     |> Enum.reduce("", fn(camera_image, mail_html) ->
       case !!camera_image.data do
         true ->
-          "#{mail_html}<img class='last-snapmail-snapshot' id='#{camera_image.exid}' src='cid:#{camera_image.exid}.jpg' alt='Last Snapshot' style='width: 100%; display:block; margin:0 auto;'><br>
+          "#{mail_html}<img class='last-snapmail-snapshot' id='#{camera_image.exid}' src='cid:#{camera_image.exid}.jpg' alt='Last Snapshot' style='width: 100% !important; max-width: 640px !important; height: auto; display:block; margin:0 auto;'><br>
           <p style='line-height: 1.6; margin: 0 0 10px; padding: 0;'><b>#{camera_image.name}</b> (#{camera_image.exid}) - See the live view on Evercam by <a style='color:#428bca; text-decoration:none;' href='https://dash.evercam.io/v2/cameras/#{camera_image.exid}'>clicking here</a></p><br>"
         _ ->
           "#{mail_html}<p style='line-height: 1.6; margin: 0 0 10px; padding: 0;'><span id='#{camera_image.exid}' class='failed-camera'>Could not retrieve live image from</span> <a target='_blank' href='https://dash.evercam.io/v2/cameras/#{camera_image.exid}'>#{camera_image.name}</a></p>"


### PR DESCRIPTION
In order to tackle the image width layout bug on the outlook for snapmail email I used the fixed image for desktop and full-size image for the mobile devices. Outlook is not very good with the inline CSS so we have to fix the width to display the image correctly in outlook emails on desktop. 