### PR TITLE
Added endpoint to check extraction status.

### DIFF
--- a/lib/evercam_media.ex
+++ b/lib/evercam_media.ex
@@ -36,7 +36,6 @@ defmodule EvercamMedia do
       :hackney_pool.child_spec(:seaweedfs_download_pool, [timeout: 5000, max_connections: 1000]),
     ]
 
-    :ets.new(:extractions, [:public, :named_table])
     :ets.new(:storage_servers, [:set, :public, :named_table])
     # See http://elixir-lang.org/docs/stable/elixir/Supervisor.html
     # for other strategies and supported options

--- a/lib/evercam_media/snapshot_extractor/extractor_supervisor.ex
+++ b/lib/evercam_media/snapshot_extractor/extractor_supervisor.ex
@@ -28,31 +28,28 @@ defmodule EvercamMedia.SnapshotExtractor.ExtractorSupervisor do
     #..Starting Local extractions.
     SnapshotExtractor.by_status(11)
     |> Enum.each(fn(extractor) ->
-      extraction_pid = spawn(fn ->
+      spawn(fn ->
         extractor
         |> start_extraction(:local)
       end)
-      :ets.insert(:extractions, {extractor.camera.exid, extraction_pid})
     end)
 
     #..Starting Cloud extractions.
     SnapshotExtractor.by_status(1)
     |> Enum.each(fn(extractor) ->
-      extraction_pid = spawn(fn ->
+      spawn(fn ->
         extractor
         |> start_extraction(:cloud)
       end)
-      :ets.insert(:extractions, {extractor.camera.exid <> "-cloud-#{extractor.id}", extraction_pid})
     end)
 
     #..Starting Timelapse extractions.
     SnapshotExtractor.by_status(21)
     |> Enum.each(fn(extractor) ->
-      extraction_pid = spawn(fn ->
+      spawn(fn ->
         extractor
         |> start_extraction(:timelapse)
       end)
-      :ets.insert(:extractions, {extractor.camera.exid <> "-timelapse-#{extractor.id}", extraction_pid})
     end)
   end
 

--- a/lib/evercam_media_web/controllers/cloud_extractions_controller.ex
+++ b/lib/evercam_media_web/controllers/cloud_extractions_controller.ex
@@ -1,0 +1,144 @@
+defmodule EvercamMediaWeb.CloudExtractionsController do
+  use EvercamMediaWeb, :controller
+  use PhoenixSwagger
+  alias EvercamMediaWeb.SnapshotExtractorView
+  alias EvercamMedia.Util
+
+  @root_dir Application.get_env(:evercam_media, :storage_dir)
+
+  swagger_path :create do
+    post "/cameras/{id}/apps/cloud-extractions"
+    summary "Create new cloud extraction of given camera."
+    parameters do
+      id :path, :string, "Unique identifier for camera.", required: true
+      from_date :path, :string, "ISO8601 (2019-02-18T09:00:00.000+00:00)", required: true
+      to_date :path, :string, "ISO8601 (2019-02-18T09:00:00.000+00:00)", required: true
+      requestor :path, :string, "Email of the person requesting extraction.", required: true
+      interval :query, :string, "", required: true, enum: ["5", "10", "15", "20", "30", "60", "300", "600", "900", "1200", "1800", "3600", "7200", "21600", "43200", "86400"]
+      schedule :query, :string, "For example in json format {\"Wednesday\":[\"8:0-18:0\"],\"Tuesday\":[\"8:0-18:0\"]}", required: true
+      api_id :query, :string, "The Evercam API id for the requester."
+      api_key :query, :string, "The Evercam API key for the requester."
+    end
+    tag "Recordings"
+    response 200, "Success"
+    response 401, "Invalid API keys"
+    response 403, "Unauthorized"
+  end
+
+  def create(conn, %{"id" => exid} = params) do
+    current_user = conn.assigns[:current_user]
+    camera = Camera.by_exid_with_associations(exid)
+
+    with :ok <- ensure_camera_exists(camera, exid, conn),
+         :ok <- ensure_can_edit(current_user, camera, conn)
+    do
+      SnapshotExtractor.changeset(%SnapshotExtractor{}, %{
+        camera_id: camera.id,
+        from_date: params["from_date"] |> NaiveDateTime.from_iso8601! |> Calendar.DateTime.from_naive("Etc/UTC") |> elem(1),
+        to_date: params["to_date"] |> NaiveDateTime.from_iso8601! |> Calendar.DateTime.from_naive("Etc/UTC") |> elem(1),
+        interval: params["interval"],
+        schedule: Jason.decode!(params["schedule"]),
+        requestor: params["requestor"],
+        jpegs_to_dropbox: true,
+        create_mp4: false,
+        inject_to_cr: false,
+        status: 1
+      })
+      |> Evercam.Repo.insert
+      |> case do
+        {:ok, extraction} ->
+          full_snapshot_extractor = Repo.preload(extraction, :camera, force: true)
+          config = %{
+            id: full_snapshot_extractor.id,
+            from_date: full_snapshot_extractor.from_date,
+            to_date: full_snapshot_extractor.to_date,
+            interval: full_snapshot_extractor.interval,
+            schedule: full_snapshot_extractor.schedule,
+            camera_exid: full_snapshot_extractor.camera.exid,
+            timezone: full_snapshot_extractor.camera.timezone,
+            camera_name: full_snapshot_extractor.camera.name,
+            requestor: full_snapshot_extractor.requestor,
+            create_mp4: full_snapshot_extractor.create_mp4,
+            jpegs_to_dropbox: full_snapshot_extractor.jpegs_to_dropbox,
+            expected_count: 0
+          }
+          spawn(fn ->
+            EvercamMedia.UserMailer.snapshot_extraction_started(full_snapshot_extractor, "Cloud")
+            start_snapshot_extractor(config)
+          end)
+          conn
+          |> put_status(:created)
+          |> put_view(SnapshotExtractorView)
+          |> render("show.json", %{snapshot_extractor: full_snapshot_extractor})
+        {:error, changeset} ->
+          render_error(conn, 400, Util.parse_changeset(changeset))
+      end
+    end
+  end
+
+  def show(conn, %{"id" => exid, "extraction_id" => extraction_id}) do
+    with  pid          <- Process.whereis(:"snapshot_extractor_#{extraction_id}"),
+          true         <- pid != nil,
+          {:ok, files} <- File.ls("#{@root_dir}/#{exid}/extract/#{extraction_id}/") do
+      json(conn, %{status: :up, jpegs: count_jpegs(files)})
+    else
+      {:ok, ["CURRENT"]} -> json(conn, %{status: :down, jpegs: 0})
+      _ -> json(conn, %{status: :down, jpegs: 0})
+    end
+  end
+
+  swagger_path :delete_extraction do
+    delete "/cameras/{id}/apps/cloud-recording/extract"
+    summary "Delete the cloud extraction"
+    parameters do
+      id :path, :string, "Unique identifier for camera.", required: true
+      extraction_id :query, :integer, "Extraction ID for the deletion of cloud extraction.", required: true
+      api_id :query, :string, "The Evercam API id for the requester."
+      api_key :query, :string, "The Evercam API key for the requester."
+    end
+    tag "Recordings"
+    response 200, "Success"
+    response 401, "Invalid API keys or Unauthorized"
+    response 404, "Snapshot extraction not found"
+  end
+
+  def delete_extraction(conn, %{"id" => exid, "extraction_id" => extraction_id}) do
+    with gen_server_pid <- Process.whereis(:"snapshot_extractor_#{extraction_id}"),
+         true           <- gen_server_pid != nil,
+         true           <- Process.exit(gen_server_pid, :kill),
+         {:ok, _}       <- File.rm_rf("#{@root_dir}/#{exid}/extract/#{extraction_id}/"),
+         {1, nil}       <- SnapshotExtractor.delete_by_id(extraction_id)
+   do
+     json(conn, %{message: "Cloud Extraction has been deleted for camera: #{exid}"})
+   else
+    _ ->
+      json(conn, %{message: "Cloud Extraction is not running for this camera."})
+   end
+  end
+
+
+  defp ensure_camera_exists(nil, exid, conn) do
+    render_error(conn, 404, "Camera '#{exid}' not found!")
+  end
+  defp ensure_camera_exists(_camera, _id, _conn), do: :ok
+
+  defp ensure_can_edit(current_user, camera, conn) do
+    case Permission.Camera.can_edit?(current_user, camera) do
+      true -> :ok
+      _ -> render_error(conn, 403, %{message: "You don't have sufficient rights for this."})
+    end
+  end
+
+  defp start_snapshot_extractor(config) do
+    name = :"snapshot_extractor_#{config.id}"
+    case Process.whereis(name) do
+      nil ->
+        {:ok, pid} = GenStage.start_link(EvercamMedia.SnapshotExtractor.CloudExtractor, {}, name: name)
+        pid
+      pid -> pid
+    end
+    |> GenStage.cast({:snapshot_extractor, config})
+  end
+
+  defp count_jpegs(files), do: files |> Enum.filter(&String.ends_with?(&1, ".jpg")) |> Enum.count()
+end

--- a/lib/evercam_media_web/controllers/cloud_recording_controller.ex
+++ b/lib/evercam_media_web/controllers/cloud_recording_controller.ex
@@ -2,120 +2,8 @@ defmodule EvercamMediaWeb.CloudRecordingController do
   use EvercamMediaWeb, :controller
   use PhoenixSwagger
   alias EvercamMedia.Snapshot.WorkerSupervisor
-  alias EvercamMediaWeb.SnapshotExtractorView
   alias EvercamMedia.Util
   import EvercamMedia.Validation.CloudRecording
-
-  @root_dir Application.get_env(:evercam_media, :storage_dir)
-
-  swagger_path :cloud_extraction do
-    post "/cameras/{id}/apps/cloud-recording/extract"
-    summary "Create new cloud extraction of given camera."
-    parameters do
-      id :path, :string, "Unique identifier for camera.", required: true
-      from_date :path, :string, "ISO8601 (2019-02-18T09:00:00.000+00:00)", required: true
-      to_date :path, :string, "ISO8601 (2019-02-18T09:00:00.000+00:00)", required: true
-      requestor :path, :string, "Email of the person requesting extraction.", required: true
-      interval :query, :string, "", required: true, enum: ["5", "10", "15", "20", "30", "60", "300", "600", "900", "1200", "1800", "3600", "7200", "21600", "43200", "86400"]
-      schedule :query, :string, "For example in json format {\"Wednesday\":[\"8:0-18:0\"],\"Tuesday\":[\"8:0-18:0\"]}", required: true
-      api_id :query, :string, "The Evercam API id for the requester."
-      api_key :query, :string, "The Evercam API key for the requester."
-    end
-    tag "Recordings"
-    response 200, "Success"
-    response 401, "Invalid API keys"
-    response 403, "Unauthorized"
-  end
-
-  def cloud_extraction(conn, %{"id" => exid} = params) do
-    current_user = conn.assigns[:current_user]
-    camera = Camera.by_exid_with_associations(exid)
-
-    with :ok <- ensure_camera_exists(camera, exid, conn),
-         :ok <- ensure_can_edit(current_user, camera, conn)
-    do
-      SnapshotExtractor.changeset(%SnapshotExtractor{}, %{
-        camera_id: camera.id,
-        from_date: params["from_date"] |> NaiveDateTime.from_iso8601! |> Calendar.DateTime.from_naive("Etc/UTC") |> elem(1),
-        to_date: params["to_date"] |> NaiveDateTime.from_iso8601! |> Calendar.DateTime.from_naive("Etc/UTC") |> elem(1),
-        interval: params["interval"],
-        schedule: Jason.decode!(params["schedule"]),
-        requestor: params["requestor"],
-        jpegs_to_dropbox: true,
-        create_mp4: false,
-        inject_to_cr: false,
-        status: 1
-      })
-      |> Evercam.Repo.insert
-      |> case do
-        {:ok, extraction} ->
-          full_snapshot_extractor = Repo.preload(extraction, :camera, force: true)
-          config = %{
-            id: full_snapshot_extractor.id,
-            from_date: full_snapshot_extractor.from_date,
-            to_date: full_snapshot_extractor.to_date,
-            interval: full_snapshot_extractor.interval,
-            schedule: full_snapshot_extractor.schedule,
-            camera_exid: full_snapshot_extractor.camera.exid,
-            timezone: full_snapshot_extractor.camera.timezone,
-            camera_name: full_snapshot_extractor.camera.name,
-            requestor: full_snapshot_extractor.requestor,
-            create_mp4: full_snapshot_extractor.create_mp4,
-            jpegs_to_dropbox: full_snapshot_extractor.jpegs_to_dropbox,
-            expected_count: 0
-          }
-          spawn(fn ->
-            EvercamMedia.UserMailer.snapshot_extraction_started(full_snapshot_extractor, "Cloud")
-            start_snapshot_extractor(config)
-          end)
-          conn
-          |> put_status(:created)
-          |> put_view(SnapshotExtractorView)
-          |> render("show.json", %{snapshot_extractor: full_snapshot_extractor})
-        {:error, changeset} ->
-          render_error(conn, 400, Util.parse_changeset(changeset))
-      end
-    end
-  end
-
-
-  def extraction_status(conn, %{"id" => exid, "extraction_id" => extraction_id}) do
-    with  _pid <- Process.whereis(:"snapshot_extractor_#{extraction_id}"),
-          {:ok, files} <- File.ls("#{@root_dir}/#{exid}/extract/#{extraction_id}/") do
-      json(conn, %{status: :up, jpegs: count_jpegs(files)})
-    else
-      {:ok, ["CURRENT"]} -> json(conn, %{status: :down, jpegs: 0})
-      _ -> json(conn, %{status: :down, jpegs: 0})
-    end
-  end
-
-  swagger_path :delete_cloud_extraction do
-    delete "/cameras/{id}/apps/cloud-recording/extract"
-    summary "Delete the cloud extraction"
-    parameters do
-      id :path, :string, "Unique identifier for camera.", required: true
-      extraction_id :query, :integer, "Extraction ID for the deletion of cloud extraction.", required: true
-      api_id :query, :string, "The Evercam API id for the requester."
-      api_key :query, :string, "The Evercam API key for the requester."
-    end
-    tag "Recordings"
-    response 200, "Success"
-    response 401, "Invalid API keys or Unauthorized"
-    response 404, "Snapshot extraction not found"
-  end
-
-  def delete_cloud_extraction(conn, %{"id" => exid, "extraction_id" => extraction_id}) do
-    with gen_server_pid           <- Process.whereis(:"snapshot_extractor_#{extraction_id}"),
-         true                     <- Process.exit(gen_server_pid, :kill),
-         {:ok, _}                 <- File.rm_rf("#{@root_dir}/#{exid}/extract/#{extraction_id}/"),
-         {1, nil}                 <- SnapshotExtractor.delete_by_id(extraction_id)
-   do
-     json(conn, %{message: "Cloud Extraction has been deleted for camera: #{exid}"})
-   else
-    _ ->
-      json(conn, %{message: "Cloud Extraction is not running for this camera."})
-   end
-  end
 
   swagger_path :show do
     get "/cameras/{id}/apps/cloud-recording"
@@ -399,17 +287,6 @@ defmodule EvercamMediaWeb.CloudRecordingController do
     end
   end
 
-  defp start_snapshot_extractor(config) do
-    name = :"snapshot_extractor_#{config.id}"
-    case Process.whereis(name) do
-      nil ->
-        {:ok, pid} = GenStage.start_link(EvercamMedia.SnapshotExtractor.CloudExtractor, {}, name: name)
-        pid
-      pid -> pid
-    end
-    |> GenStage.cast({:snapshot_extractor, config})
-  end
-
   defp get_times_list(true, starttime_list, endtime_list) do
     starttime_list
     |> Enum.with_index
@@ -586,6 +463,4 @@ defmodule EvercamMediaWeb.CloudRecordingController do
 
   defp get_action_log(nil), do: "created"
   defp get_action_log(_cloud_recording), do: "updated"
-
-  defp count_jpegs(files), do: files |> Enum.filter(&String.ends_with?(&1, ".jpg")) |> Enum.count()
 end

--- a/lib/evercam_media_web/controllers/nvr_controller.ex
+++ b/lib/evercam_media_web/controllers/nvr_controller.ex
@@ -92,7 +92,10 @@ defmodule EvercamMediaWeb.NVRController do
          {:ok, _}  <- File.rm_rf("#{@root_dir}/#{exid}/extract/#{extraction_id}/"),
          {1, nil}  <- SnapshotExtractor.delete_by_id(extraction_id)
    do
-     json(conn, %{message: "Extraction has been deleted"})
+      spawn(fn ->
+        Porcelain.shell("for pid in $(ps -ef | grep ffmpeg | grep '#{exid}' | grep -v grep |  awk '{print $2}'); do kill -9 $pid; done")
+      end)
+      json(conn, %{message: "Extraction has been deleted"})
    else
     _ ->
       json(conn, %{message: "Extraction is not running for this camera."})

--- a/lib/evercam_media_web/controllers/nvr_controller.ex
+++ b/lib/evercam_media_web/controllers/nvr_controller.ex
@@ -87,6 +87,7 @@ defmodule EvercamMediaWeb.NVRController do
 
   def delete_extraction(conn, %{"id" => exid, "extraction_id" => extraction_id}) do
     with pid       <- Process.whereis(:"snapshot_extractor_#{extraction_id}"),
+         true      <- pid != nil,
          true      <- Process.exit(pid, :kill),
          {:ok, _}  <- File.rm_rf("#{@root_dir}/#{exid}/extract/#{extraction_id}/"),
          {1, nil}  <- SnapshotExtractor.delete_by_id(extraction_id)

--- a/lib/evercam_media_web/controllers/timelapse_creator_controller.ex
+++ b/lib/evercam_media_web/controllers/timelapse_creator_controller.ex
@@ -132,10 +132,9 @@ defmodule EvercamMediaWeb.TimelapseCreatorController do
             headers: video_params["headers"],
             exid: exid,
           }
-          extraction_pid = spawn(fn ->
+          spawn(fn ->
             start_snapshot_extractor(config)
           end)
-          :ets.insert(:extractions, {exid <> "-timelapse-#{full_snapshot_extractor.id}", extraction_pid})
           conn
           |> put_status(:created)
           |> put_view(SnapshotExtractorView)

--- a/lib/evercam_media_web/router.ex
+++ b/lib/evercam_media_web/router.ex
@@ -175,6 +175,7 @@ end
       options "/cameras/:id/apps/cloud-recording", CloudRecordingController, :nothing
       post "/cameras/:id/apps/cloud-recording", CloudRecordingController, :create
 
+      get "/cameras/:id/apps/cloud-recording/extract", CloudRecordingController, :extraction_status
       post "/cameras/:id/apps/cloud-recording/extract", CloudRecordingController, :cloud_extraction
       options "/cameras/:id/apps/cloud-recording/extract", CloudRecordingController, :nothing
       delete "/cameras/:id/apps/cloud-recording/extract", CloudRecordingController, :delete_cloud_extraction

--- a/lib/evercam_media_web/router.ex
+++ b/lib/evercam_media_web/router.ex
@@ -175,10 +175,10 @@ end
       options "/cameras/:id/apps/cloud-recording", CloudRecordingController, :nothing
       post "/cameras/:id/apps/cloud-recording", CloudRecordingController, :create
 
-      get "/cameras/:id/apps/cloud-recording/extract", CloudRecordingController, :extraction_status
-      post "/cameras/:id/apps/cloud-recording/extract", CloudRecordingController, :cloud_extraction
-      options "/cameras/:id/apps/cloud-recording/extract", CloudRecordingController, :nothing
-      delete "/cameras/:id/apps/cloud-recording/extract", CloudRecordingController, :delete_cloud_extraction
+      get "/cameras/:id/apps/cloud-extractions", CloudExtractionsController, :show
+      post "/cameras/:id/apps/cloud-extractions", CloudExtractionsController, :create
+      options "/cameras/:id/apps/cloud-extractions", CloudExtractionsController, :nothing
+      delete "/cameras/:id/apps/cloud-extractions", CloudExtractionsController, :delete_extraction
 
       # Share and share-request route
       get "/cameras/:id/shares", CameraShareController, :show


### PR DESCRIPTION
The endpoint is the same as for POST or DELETE but its a GET.

```
get "/cameras/:id/apps/cloud-recording/extract", CloudRecordingController, :extraction_status
```

which will return the extraction state i.e up and down. also with jpegs extracted until now.

Also removed the use of ets table for saving extraction PID. in Past we were running GenServer with single name as `snapshot_extractor` but now its always a unique name with extraction id. So We don't need it anymore to differentiate between the process. 