### PR TITLE
Remove unnecessary application list in mix.exs

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -21,58 +21,8 @@ defmodule EvercamMedia.Mixfile do
   end
 
   def application do
-    [mod: {EvercamMedia, []},
-     applications: app_list(Mix.env)]
+    [mod: {EvercamMedia, []}, extra_applications: [:runtime_tools]]
   end
-
-  defp app_list(:dev), do: [:dotenv, :credo | app_list()]
-  defp app_list(:test), do: [:dotenv | app_list()]
-  defp app_list(_), do: app_list()
-  defp app_list, do: [
-    :calendar,
-    :cf,
-    :bcrypt_elixir,
-    :con_cache,
-    :connection,
-    :cors_plug,
-    :plug_cowboy,
-    :ecto,
-    :ecto_sql,
-    :httpoison,
-    :inets,
-    :jsx,
-    :phoenix_swoosh,
-    :swoosh,
-    :meck,
-    :phoenix,
-    :phoenix_ecto,
-    :phoenix_html,
-    :phoenix_pubsub,
-    :porcelain,
-    :postgrex,
-    :quantum,
-    :runtime_tools,
-    :timex,
-    :tzdata,
-    :erlware_commons,
-    :uuid,
-    :xmerl,
-    :html_sanitize_ex,
-    :gen_stage,
-    :ex_aws,
-    :configparser_ex,
-    :sweet_xml,
-    :phoenix_swagger,
-    :ex_json_schema,
-    :nadia,
-    :geoip,
-    :poolboy,
-    :evercam_models,
-    :joken,
-    :export,
-    :jason,
-    :exexif
-  ]
 
   # Specifies which paths to compile per environment
   defp elixirc_paths(:test), do: ["lib", "test/support"]


### PR DESCRIPTION
Long time no see :)

Since Elixir 1.4, it's not necessary to explicitly list the applications that need to be started, they're automatically inferred: https://github.com/elixir-lang/elixir/blob/v1.4/CHANGELOG.md#application-inference

So this change should just work.